### PR TITLE
Create a separate unit for storing the build version

### DIFF
--- a/.github/build_macos.sh
+++ b/.github/build_macos.sh
@@ -60,7 +60,7 @@ else
 fi
 
 build=$(git rev-list --abbrev-commit --max-count=1 HEAD)
-sed -i.bak -e "s/@GIT_COMMIT@/$build/" about.lfm
+sed -i.bak -e "s/@GIT_COMMIT@/$build/" buildinfo.pas
 
 cd "${repo_dir}/.github/macosx"
 source create_app_new.sh

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -45,7 +45,7 @@ else
 fi
 
 build=$(git rev-list --abbrev-commit --max-count=1 HEAD)
-sed -i "s/@GIT_COMMIT@/$build/" about.lfm
+sed -i "s/@GIT_COMMIT@/$build/" buildinfo.pas
 
 lazbuild transgui.lpi --ws=qt5 --build-mode=Release --lazarusdir=${sdk_dir}/lazarus
 cd units

--- a/.github/build_windows.ps1
+++ b/.github/build_windows.ps1
@@ -69,7 +69,7 @@ else
 
 cd $repodir
 $build = git rev-list --abbrev-commit --max-count=1 HEAD
-((Get-Content -path about.lfm -Raw) -replace '@GIT_COMMIT@',${build}) | Set-Content -Path about.lfm
+((Get-Content -path buildinfo.pas -Raw) -replace '@GIT_COMMIT@',${build}) | Set-Content -Path buildinfo.pas
 lazbuild --build-mode=Release --lazarusdir=${sdk_dir}\lazarus transgui.lpi
 
 mkdir Release

--- a/.github/macosx/create_app_new.sh
+++ b/.github/macosx/create_app_new.sh
@@ -82,7 +82,3 @@ SetFile -a C "$mount_volume"
 hdiutil detach "$mount_device"
 rm -f "$dmg_dist_file"
 hdiutil convert tmp.dmg -format UDBZ -imagekey zlib-level=9 -o "$dmg_dist_file"
-
-rm tmp.dmg
-rm -rf "$dmgfolder"
-mv ../../about.lfm.bak ../../about.lfm

--- a/about.lfm
+++ b/about.lfm
@@ -500,7 +500,7 @@ inherited AboutForm: TAboutForm
         Height = 15
         Top = 38
         Width = 57
-        Caption = 'Version %s, Build @GIT_COMMIT@'
+        Caption = 'Version %s, Build %s'
         ParentColor = False
       end
       object Bevel1: TBevel

--- a/about.pas
+++ b/about.pas
@@ -36,8 +36,9 @@ unit About;
 interface
 
 uses
-  BaseForm, Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics, Dialogs, StdCtrls, ComCtrls, ExtCtrls, ButtonPanel, lclversion,
-    ssl_openssl3, ssl_openssl3_lib;
+  BaseForm, Classes, SysUtils, FileUtil, LResources, Forms, Controls, Graphics,
+  Dialogs, StdCtrls, ComCtrls, ExtCtrls, ButtonPanel, lclversion, BuildInfo,
+  ssl_openssl3, ssl_openssl3_lib;
 
 resourcestring
   SErrorCheckingVersion = 'Error checking for new version.';
@@ -239,7 +240,7 @@ begin
   txHomePage.Font.Size:=Font.Size;
   BorderStyle:=bsSizeable;
   txAppName.Caption:=AppName;
-  txVersion.Caption:=Format(txVersion.Caption, [AppVersion]);
+  txVersion.Caption:=Format(txVersion.Caption, [AppVersion, BuildInfo.GIT_COMMIT]);
   Page.ActivePageIndex:=0;
 
   txVersFPC.caption := 'Fpc : ' + {$I %FPCVERSION%} + '   Lazarus : ' +lcl_version;

--- a/buildinfo.pas
+++ b/buildinfo.pas
@@ -1,0 +1,43 @@
+{*************************************************************************************
+  This file is part of Transmission Remote GUI.
+  Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group.
+
+  Transmission Remote GUI is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  Transmission Remote GUI is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Transmission Remote GUI; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  In addition, as a special exception, the copyright holders give permission to
+  link the code of portions of this program with the
+  OpenSSL library under certain conditions as described in each individual
+  source file, and distribute linked combinations including the two.
+
+  You must obey the GNU General Public License in all respects for all of the
+  code used other than OpenSSL.  If you modify file(s) with this exception, you
+  may extend this exception to your version of the file(s), but you are not
+  obligated to do so.  If you do not wish to do so, delete this exception
+  statement from your version.  If you delete this exception statement from all
+  source files in the program, then also delete it here.
+*************************************************************************************}
+
+unit BuildInfo;
+
+{$mode objfpc}{$H+}
+
+interface
+
+const
+  GIT_COMMIT = '@GIT_COMMIT@';
+
+implementation
+
+end.

--- a/main.pas
+++ b/main.pas
@@ -999,7 +999,7 @@ procedure ReadVersionInfo;
 var
   file_ver_info : TFileVersionInfo;
 begin
-  {{ https://wiki.lazarus.freepascal.org/Show_Application_Title,_Version,_and_Company }}
+  { https://wiki.lazarus.freepascal.org/Show_Application_Title,_Version,_and_Company }
   file_ver_info := TFileVersionInfo.Create(nil);
   try
     file_ver_info.ReadFileInfo;

--- a/transgui.lpi
+++ b/transgui.lpi
@@ -404,6 +404,11 @@
         <UnitName Value="IpResolver"/>
       </Unit>
       <Unit>
+        <Filename Value="buildinfo.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="BuildInfo"/>
+      </Unit>
+      <Unit>
         <Filename Value="download.pas"/>
         <IsPartOfProject Value="True"/>
         <ComponentName Value="DownloadForm"/>


### PR DESCRIPTION
Strings in `about.lfm` are resourcestrings, so the previous approach would cause the resulting string to be never available in translated form.