### PR TITLE
Update references to old account name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "synapse/source/lib"]
 	path = synapse/source/lib
-	url = https://github.com/xavery/synapse.git
+	url = https://github.com/lighterowl/synapse.git

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This place is meant to be a temporary home for Transmission Remote GUI as both t
 You need to clone the repository with submodules, and then use `lazbuild` to build :
 
 ```
-git clone --recurse-submodules https://github.com/xavery/transgui.git
+git clone --recurse-submodules https://github.com/lighterowl/transgui.git
 cd transgui
 lazbuild transgui.lpi
 ```
@@ -18,9 +18,9 @@ If you hit trouble, have a look at `build_` scripts in the `.github` folder. The
 
 Due to issues with fpc 3.2.2 mentioned below, it is recommended to build transgui with a development version of the Free Pascal compiler. The `build_` scripts include necessary code that downloads and compiles the development version from source.
 
-Also, due to the fix for [one issue](https://github.com/xavery/transgui/issues/25), there was a need to introduce a change to Lazarus code. This version of transgui thus now uses [my own fork of Lazarus](https://gitlab.com/dkk089/lazarus/-/tree/transgui). If you don't want to use it, just remove the offending line when compiling with upstream Lazarus - stuff will still work.
+Also, due to the fix for [one issue](https://github.com/lighterowl/transgui/issues/25), there was a need to introduce a change to Lazarus code. This version of transgui thus now uses [my own fork of Lazarus](https://gitlab.com/dkk089/lazarus/-/tree/transgui). If you don't want to use it, just remove the offending line when compiling with upstream Lazarus - stuff will still work.
 
-You're encouraged to read the [wiki](https://github.com/xavery/transgui/wiki) if you're looking into making changes yourself.
+You're encouraged to read the [wiki](https://github.com/lighterowl/transgui/wiki) if you're looking into making changes yourself.
 
 # Changes made
 

--- a/about.lfm
+++ b/about.lfm
@@ -491,7 +491,7 @@ inherited AboutForm: TAboutForm
         Top = 104
         Width = 307
         AutoSize = False
-        Caption = 'Fork maintained by xavery.'#10'Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group'
+        Caption = 'Fork maintained by lighterowl.'#10'Copyright (c) 2008-2019 by Yury Sidorov and Transmission Remote GUI working group'
         ParentColor = False
         WordWrap = True
       end

--- a/about.pas
+++ b/about.pas
@@ -125,14 +125,14 @@ end;
 procedure GoHomePage;
 begin
   AppBusy;
-  OpenURL('https://github.com/xavery/transgui/releases/latest');
+  OpenURL('https://github.com/lighterowl/transgui/releases/latest');
   AppNormal;
 end;
 
 procedure GoGitHub;
 begin
   AppBusy;
-  OpenURL('https://github.com/xavery/transgui');
+  OpenURL('https://github.com/lighterowl/transgui');
   AppNormal;
 end;
 
@@ -156,7 +156,7 @@ begin
 
   Application.ProcessMessages;
   AppBusy;
-  OpenURL('https://github.com/xavery/transgui/releases');
+  OpenURL('https://github.com/lighterowl/transgui/releases');
   AppNormal;
 end;
 
@@ -195,7 +195,7 @@ begin
           FHttp.ProxyUser:=RpcObj.Http.ProxyUser;
           FHttp.ProxyPass:=RpcObj.Http.ProxyPass;
         end;
-        if FHttp.HTTPMethod('GET', 'https://api.github.com/repos/xavery/transgui/releases/latest') then begin
+        if FHttp.HTTPMethod('GET', 'https://api.github.com/repos/lighterowl/transgui/releases/latest') then begin
           if FHttp.ResultCode = 200 then begin
             parsed := GetJSON(FHttp.Document) as TJSONObject;
             FVersion := Copy(parsed.Strings['name'], 2);


### PR DESCRIPTION
Old URL redirects, but update-checker code doesn't support redirects.

Resolves issue #87 