### PR TITLE
Don't pass 0 as 'vk' to RegisterHotKey

### DIFF
--- a/main.pas
+++ b/main.pas
@@ -1010,14 +1010,14 @@ end;
 
 procedure TMainForm.SetUpWindowsHotKey;
 var
-  GlobalHotKey, GlobalHotKeyMod: string;
+  VKKey, VKModifier: word;
 begin
-  GlobalHotKey:=Ini.ReadString('Interface','GlobalHotkey','');
-  GlobalHotKeyMod:=Ini.ReadString('Interface','GlobalHotkeyMod','');
-  if GlobalHotKey <> '' then begin
+  VKKey:=VKStringToWord(Ini.ReadString('Interface','GlobalHotkey',''));
+  VKModifier:=VKStringToWord(Ini.ReadString('Interface','GlobalHotkeyMod',''));
+  if VKKey <> 0 then begin
     HotKeyID:=GlobalAddAtom('TransGUIHotkey');
     PrevWndProc:=windows.WNDPROC(SetWindowLongPtr(Self.Handle,GWL_WNDPROC,PtrInt(@WndCallback)));
-    RegisterHotKey(Self.Handle,HotKeyID, VKStringToWord(GlobalHotKeyMod), VKStringToWord(GlobalHotKey));
+    RegisterHotKey(Self.Handle,HotKeyID, VKModifier, VKKey);
   end;
 end;
 

--- a/transgui.lpi
+++ b/transgui.lpi
@@ -296,6 +296,11 @@
               <GenerateDebugInfo Value="False"/>
             </Debugging>
             <LinkSmart Value="True"/>
+            <Options>
+              <Win32>
+                <GraphicApplication Value="True"/>
+              </Win32>
+            </Options>
           </Linking>
           <Other>
             <Verbosity>
@@ -504,6 +509,7 @@
       <Unit>
         <Filename Value="trackeruri.pas"/>
         <IsPartOfProject Value="True"/>
+        <UnitName Value="TrackerUri"/>
       </Unit>
       <Unit>
         <Filename Value="macosthemedetect.pas"/>

--- a/transgui.lpr
+++ b/transgui.lpr
@@ -22,10 +22,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 *************************************************************************************}
 
-{$ifdef windows}
-{$apptype gui}
-{$endif windows}
-
 program transgui;
 
 {$mode objfpc}{$H+}
@@ -39,20 +35,14 @@ uses
   clocale,
   {$endif}
 {$endif}
-  Interfaces, // this includes the LCL widgetset
-  Forms
-  { you can add units after this }, BaseForm, Main, rpc, AddTorrent,
+  Interfaces, Forms, BaseForm, Main, rpc, AddTorrent,
   ConnOptions, varlist, TorrProps, DaemonOptions, About, IpResolver, download,
   ColSetup, utils, ResTranslator, AddLink, MoveTorrent, AddTracker, Options,
   passwcon;
 
-//{$ifdef windows}
 {$R *.res}
-//{$endif}
 
 begin
-//Application.Scaled:=True; //travis doesnt compile
-
   if not CheckAppParams then exit;
 
   Application.Initialize;


### PR DESCRIPTION
Fixes #85.

It seems like clicking _any_ Windows notification (i.e. not just Chrome) causes the window procedure to be called with `WM_HOTKEY`. However, this is the case only if the `vk` argument to the `RegisterHotKey` call is zero. Zero isn't a valid [Virtual Key Code](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) so we shouldn't call the function at all in the first place.