### PR TITLE
Switch to FPC 3.2.4-rc1 and Lazarus 3.4

### DIFF
--- a/.github/build_macos.sh
+++ b/.github/build_macos.sh
@@ -4,8 +4,8 @@ set -xe
 
 readonly repo_dir=$PWD
 readonly sdk_dir=~/.transgui_sdk
-readonly fpc_installdir="${sdk_dir}/fpc-3.2.3"
-readonly fpc_basepath="${fpc_installdir}/lib/fpc/3.2.3"
+readonly fpc_installdir="${sdk_dir}/fpc-3.2.4-rc1"
+readonly fpc_basepath="${fpc_installdir}/lib/fpc/3.2.4"
 readonly brew_prefix=$(brew --prefix)
 readonly macosx_libdir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
 readonly macosx_frameworkdir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks
@@ -32,10 +32,12 @@ fpc_lazarus_build_install() {
 
   mkdir -p "$sdk_dir"
   cd "$sdk_dir"
-  readonly fpc323_commit='0c5256300a323c78caa0b1a9cb772ac137f5aa8e'
-  curl -O "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc323_commit}/source-${fpc323_commit}.tar.gz"
-  tar xf "source-${fpc323_commit}.tar.gz"
-  cd "source-${fpc323_commit}"
+
+  readonly fpc324_rc1_commit='d78e2897014a69f56a1cfb53c75335c4cc37ba0e'
+  curl -L -o fpc-src.tar.bz2 "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc324_rc1_commit}/source-${fpc324_rc1_commit}.tar.bz2"
+  tar xf fpc-src.tar.bz2
+  mv "source-${fpc324_rc1_commit}" fpc-src
+  cd fpc-src
 
   mkdir -p "${fpc_installdir}"
 
@@ -57,9 +59,9 @@ fpc_lazarus_build_install() {
   make_fpc_cfg
 
   cd "$sdk_dir"
-  local -r lazarus_commit='63dda919964be2dead48c0fdb018a02a95727e16'
-  curl -L -o lazarus-src.tar.gz "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.tar.gz"
-  tar xf lazarus-src.tar.gz
+  local -r lazarus_commit='4e69368d79e3801ad26a7bc7c1eda0ad3cf7dcc4'
+  curl -L -o lazarus-src.tar.bz2 "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.tar.bz2"
+  tar xf lazarus-src.tar.bz2
   mv "lazarus-${lazarus_commit}" lazarus
   cd lazarus
   make bigide
@@ -109,7 +111,7 @@ package_openssl() {
 }
 
 my_lazbuild() {
-  lazbuild --compiler=${fpc_installdir}/lib/fpc/3.2.3/${compiler} \
+  lazbuild "--compiler=${fpc_basepath}/${compiler}" \
     --lazarusdir=${sdk_dir}/lazarus "$@"
 }
 

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -37,7 +37,12 @@ fpc_lazarus_build_install() {
 }
 
 sudo apt update -yqq
-sudo apt install -yqq build-essential libqt5pas-dev libfuse2 qtbase5-dev-tools qt5-qmake libxml2-utils
+sudo apt install -yqq build-essential libfuse2 qtbase5-dev-tools qt5-qmake libxml2-utils
+
+curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
+curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
+dpkg -i libqt5pas1_2.15-1_amd64.deb
+dpkg -i libqt5pas-dev_2.15-1_amd64.deb
 
 if [[ -d $sdk_dir ]]; then
   export PATH=${sdk_dir}/lazarus:${fpc_installdir}/bin:${fpc_basepath}:$PATH

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -27,9 +27,10 @@ fpc_lazarus_build_install() {
   fpcmkcfg -d basepath=${fpc_basepath} -o ~/.fpc.cfg
 
   cd "$sdk_dir"
-  curl -L -o lazarus-src.tar.gz 'https://gitlab.com/dkk089/lazarus/-/archive/transgui/lazarus-transgui.tar.gz'
-  tar xf lazarus-src.tar.gz
-  mv lazarus-transgui lazarus
+  local -r lazarus_commit='4e69368d79e3801ad26a7bc7c1eda0ad3cf7dcc4'
+  curl -L -o lazarus-src.tar.bz2 "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.tar.bz2"
+  tar xf lazarus-src.tar.bz2
+  mv "lazarus-${lazarus_commit}" lazarus
   cd lazarus
   make bigide LCL_PLATFORM=qt5
   export PATH=$PWD:$PATH

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -41,8 +41,8 @@ sudo apt install -yqq build-essential libfuse2 qtbase5-dev-tools qt5-qmake libxm
 
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
-dpkg -i libqt5pas1_2.15-1_amd64.deb
-dpkg -i libqt5pas-dev_2.15-1_amd64.deb
+sudo dpkg -i libqt5pas1_2.15-1_amd64.deb
+sudo dpkg -i libqt5pas-dev_2.15-1_amd64.deb
 
 if [[ -d $sdk_dir ]]; then
   export PATH=${sdk_dir}/lazarus:${fpc_installdir}/bin:${fpc_basepath}:$PATH

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -41,8 +41,7 @@ sudo apt install -yqq build-essential libfuse2 qtbase5-dev-tools qt5-qmake libxm
 
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
-sudo dpkg -i libqt5pas1_2.15-1_amd64.deb
-sudo dpkg -i libqt5pas-dev_2.15-1_amd64.deb
+sudo apt install libqt5pas1_2.15-1_amd64.deb libqt5pas-dev_2.15-1_amd64.deb
 
 if [[ -d $sdk_dir ]]; then
   export PATH=${sdk_dir}/lazarus:${fpc_installdir}/bin:${fpc_basepath}:$PATH

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -41,7 +41,7 @@ sudo apt install -yqq build-essential libfuse2 qtbase5-dev-tools qt5-qmake libxm
 
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas1_2.15-1_amd64.deb
 curl -L -O https://github.com/davidbannon/libqt5pas/releases/download/v1.2.15/libqt5pas-dev_2.15-1_amd64.deb
-sudo apt install libqt5pas1_2.15-1_amd64.deb libqt5pas-dev_2.15-1_amd64.deb
+sudo apt install ./libqt5pas1_2.15-1_amd64.deb ./libqt5pas-dev_2.15-1_amd64.deb
 
 if [[ -d $sdk_dir ]]; then
   export PATH=${sdk_dir}/lazarus:${fpc_installdir}/bin:${fpc_basepath}:$PATH

--- a/.github/build_ubuntu.sh
+++ b/.github/build_ubuntu.sh
@@ -4,8 +4,8 @@ set -xe
 
 readonly repo_dir=$PWD
 readonly sdk_dir=~/.transgui_sdk
-readonly fpc_installdir="${sdk_dir}/fpc-3.2.3"
-readonly fpc_basepath="${fpc_installdir}/lib/fpc/3.2.3"
+readonly fpc_installdir="${sdk_dir}/fpc-3.2.4-rc1"
+readonly fpc_basepath="${fpc_installdir}/lib/fpc/3.2.4"
 
 fpc_lazarus_build_install() {
   sudo apt install -yqq --no-install-recommends fpc build-essential
@@ -14,10 +14,11 @@ fpc_lazarus_build_install() {
 
   mkdir -p "$sdk_dir"
   cd "$sdk_dir"
-  readonly fpc323_commit='0c5256300a323c78caa0b1a9cb772ac137f5aa8e'
-  curl -O "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc323_commit}/source-${fpc323_commit}.tar.gz"
-  tar xf "source-${fpc323_commit}.tar.gz"
-  cd "source-${fpc323_commit}"
+  readonly fpc324_rc1_commit='d78e2897014a69f56a1cfb53c75335c4cc37ba0e'
+  curl -L -o fpc-src.tar.bz2 "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc324_rc1_commit}/source-${fpc324_rc1_commit}.tar.bz2"
+  tar xf fpc-src.tar.bz2
+  mv "source-${fpc324_rc1_commit}" fpc-src
+  cd fpc-src
 
   make all
   mkdir -p "${fpc_installdir}"

--- a/.github/build_windows.ps1
+++ b/.github/build_windows.ps1
@@ -15,7 +15,7 @@ function My-Download {
 
 $sdk_dir = "${HOME}\transgui_sdk"
 $fpc322 = "${sdk_dir}\fpc-3.2.2"
-$fpc323 = "${sdk_dir}\fpc-3.2.3"
+$fpc324 = "${sdk_dir}\fpc-3.2.4-rc1"
 $lazarus = "${sdk_dir}\lazarus"
 $openssl = "${sdk_dir}\OpenSSL"
 
@@ -28,26 +28,26 @@ function FPC-Lazarus-Build-Install {
 
     $env:Path = "${fpc322}\bin\i386-win32;" + $env:Path
 
-    # top of fixes_3_2 at the time of writing
-    $fpc323_commit = '0c5256300a323c78caa0b1a9cb772ac137f5aa8e'
-    My-Download -Uri "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc323_commit}/source-${fpc323_commit}.zip" -OutFile fpc-fixes.zip
+    $fpc324_commit = 'd78e2897014a69f56a1cfb53c75335c4cc37ba0e'
+    My-Download -Uri "https://gitlab.com/freepascal.org/fpc/source/-/archive/${fpc324_commit}/source-${fpc324_commit}.zip" -OutFile fpc-324-rc1.zip
 
     # we could use Expand-Archive but it takes an eternity and then some
-    7z x fpc-fixes.zip
+    7z x fpc-324-rc1.zip
 
-    cd "source-${fpc323_commit}"
+    cd "source-${fpc324_commit}"
     make all
-    mkdir "$fpc323"
-    make PREFIX=${fpc323} install
+    mkdir "$fpc324"
+    make PREFIX=${fpc324} install
 
-    $env:Path = "${fpc323}\bin\i386-win32;" + $env:Path
-    fpcmkcfg -d basepath=${fpc323} -o "${fpc323}\bin\i386-win32\fpc.cfg"
+    $env:Path = "${fpc324}\bin\i386-win32;" + $env:Path
+    fpcmkcfg -d basepath=${fpc324} -o "${fpc324}\bin\i386-win32\fpc.cfg"
 
     cd "$sdk_dir"
-    My-Download -Uri "https://gitlab.com/dkk089/lazarus/-/archive/transgui/lazarus-transgui.zip" -OutFile lazarus-src.zip
-    7z x lazarus-src.zip
+    $lazarus_commit = '4e69368d79e3801ad26a7bc7c1eda0ad3cf7dcc4'
+    My-Download -Uri "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.zip" -OutFile lazarus-src.zip
+    7z x lazarus-${lazarus_commit}.zip
 
-    mv lazarus-transgui lazarus
+    mv lazarus-${lazarus_commit} lazarus
     cd lazarus
     make bigide
     $env:Path = "${lazarus};" + $env:Path

--- a/.github/build_windows.ps1
+++ b/.github/build_windows.ps1
@@ -45,7 +45,7 @@ function FPC-Lazarus-Build-Install {
     cd "$sdk_dir"
     $lazarus_commit = '4e69368d79e3801ad26a7bc7c1eda0ad3cf7dcc4'
     My-Download -Uri "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.zip" -OutFile lazarus-src.zip
-    7z x lazarus-${lazarus_commit}.zip
+    7z x lazarus-src.zip
 
     mv lazarus-${lazarus_commit} lazarus
     cd lazarus

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         path: |
           ~/.transgui_sdk/lazarus
-          ~/.transgui_sdk/fpc-3.2.3
+          ~/.transgui_sdk/fpc-3.2.4-rc1
         key: macos-arm64-fpc-lazarus
 
     - run: .github/build_macos.sh
@@ -44,7 +44,7 @@ jobs:
       with:
         path: |
           ~/.transgui_sdk/lazarus
-          ~/.transgui_sdk/fpc-3.2.3
+          ~/.transgui_sdk/fpc-3.2.4-rc1
         key: macos-x64-fpc-lazarus
 
     - run: .github/build_macos.sh

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         path: |
           ~/.transgui_sdk/lazarus
-          ~/.transgui_sdk/fpc-3.2.3
+          ~/.transgui_sdk/fpc-3.2.4-rc1
         key: ubuntu-fpc-lazarus
 
     - run: .github/build_ubuntu.sh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: |
-          ~\transgui_sdk\fpc-3.2.3
+          ~\transgui_sdk\fpc-3.2.4-rc1
           ~\transgui_sdk\lazarus
           ~\transgui_sdk\OpenSSL\bin\libcrypto-3.dll
           ~\transgui_sdk\OpenSSL\bin\libssl-3.dll

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 ### https://raw.github.com/github/gitignore/8edb8a95c4c4b3dce71a378aaaf89275510b9cef/Global/Lazarus.gitignore
 
-
 # Lazarus compiler-generated binaries (safe to delete)
 *.exe
 *.dll

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### https://raw.github.com/github/gitignore/8edb8a95c4c4b3dce71a378aaaf89275510b9cef/Global/Lazarus.gitignore
 
+
 # Lazarus compiler-generated binaries (safe to delete)
 *.exe
 *.dll

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-
-# snap package build via snapcraft
-/*.snap
-/snap/.snapcraft/
-/stage/
-/parts/
-/prime/
-
 ### https://raw.github.com/github/gitignore/8edb8a95c4c4b3dce71a378aaaf89275510b9cef/Global/Lazarus.gitignore
 
 # Lazarus compiler-generated binaries (safe to delete)
@@ -40,7 +32,6 @@ units
 # Application bundle for Mac OS
 *.app/
 
-
 # Free Pascal compiler made files
 fpcmade*
 
@@ -52,3 +43,7 @@ Release/
 
 # transgui binary
 /transgui
+
+# binaries on macos
+/transgui_*/
+.DS_Store

--- a/main.pas
+++ b/main.pas
@@ -1895,11 +1895,13 @@ begin
         if j <> 0 then StatusBar.Panels[i].Width:=j else
                   Ini.WriteInteger('StatusBarPanels',IntToStr(i),Statusbar.Panels[i].Width);
   end;
-  {$IF LCL_FULLVERSION >= 1080000}
-  PageInfo.Options := PageInfo.Options + [nboDoChangeOnSetIndex];
-  {$ENDIF}
 
+  PageInfo.Options := PageInfo.Options + [nboDoChangeOnSetIndex];
   FilterTimer.Interval := 100;
+{$if not declared(lcl_custom_transgui)}
+  acKeepSelectionInTables.Checked := True;
+  acKeepSelectionInTables.Enabled := False;
+{$endif}
 end;
 
 procedure TMainForm.FormDestroy(Sender: TObject);
@@ -3637,8 +3639,10 @@ end;
 procedure TMainForm.acKeepSelectionInTablesExecute(Sender: TObject);
 begin
   acKeepSelectionInTables.Checked := not acKeepSelectionInTables.Checked;
+{$if declared(lcl_custom_transgui)}
   if acKeepSelectionInTables.Checked then gTorrents.Options2:=[]
   else gTorrents.Options2:=[goNoScrollAfterSetRow];
+{$endif}
   Ini.WriteBool('Interface','KeepTableSelection',acKeepSelectionInTables.Checked);
 end;
 

--- a/vargrid.pas
+++ b/vargrid.pas
@@ -1166,16 +1166,10 @@ begin
   Result:=inherited DoMouseWheel(Shift, WheelDelta, MousePos);
   if not Result then begin
     if Mouse.WheelScrollLines = -1 then
-  {$IF LCL_FULLVERSION < 1080000}
-      GridMouseWheel(Shift, -WheelDelta*VisibleRowCount div 120)
-    else
-      GridMouseWheel(Shift, -WheelDelta*Mouse.WheelScrollLines div 120);
-  {$ENDIF}
-  {$IF LCL_FULLVERSION >= 1080000}
       GridMouseWheel(Shift, WheelDelta*VisibleRowCount div 120)
     else
       GridMouseWheel(Shift, -WheelDelta div 120);
-  {$ENDIF}
+
       Result := True;
   end;
 end;


### PR DESCRIPTION
FPC 3.2.4-rc1 officially branched off last week so it might be a good idea to use it instead of sticking with the fixes branch.

Also, use this chance to update to Lazarus 3.4 because why not.