### PR TITLE
Remove all references to CPUARM define

### DIFF
--- a/.github/build_macos.sh
+++ b/.github/build_macos.sh
@@ -60,7 +60,7 @@ fpc_lazarus_build_install() {
   make_fpc_cfg
 
   cd "$sdk_dir"
-  local -r lazarus_commit='dab5c509c6fd70f8fac2144e468291899286616f'
+  local -r lazarus_commit='cf6b6acfad7d35bcb97d9f763c1f9b7c1ecc2a5d'
   curl -L -o lazarus-src.tar.bz2 "https://gitlab.com/dkk089/lazarus/-/archive/${lazarus_commit}/lazarus-${lazarus_commit}.tar.bz2"
   tar xf lazarus-src.tar.bz2
   mv "lazarus-${lazarus_commit}" lazarus

--- a/main.pas
+++ b/main.pas
@@ -2912,13 +2912,11 @@ end;
 
 procedure TMainForm.UpdateTray;
 begin
-{$ifndef CPUARM}
   TrayIcon.Visible:=not IsUnity and
     (Ini.ReadBool('Interface', 'TrayIconAlways', True)  or
     ((WindowState = wsMinimized) and Ini.ReadBool('Interface', 'TrayMinimize', True) ) or
     (not Self.Visible and Ini.ReadBool('Interface', 'TrayClose', False) )
     );
-{$endif CPUARM}
 
 {$ifdef darwin}
   acShowApp.Visible:=False;
@@ -2959,12 +2957,10 @@ end;
 
 procedure TMainForm.DownloadFinished(const TorrentName: string);
 begin
-{$ifndef CPUARM}
   if not TrayIcon.Visible or not Ini.ReadBool('Interface', 'TrayNotify', True) then exit;
   TrayIcon.BalloonHint:=Format(sFinishedDownload, [TorrentName]);
   TrayIcon.BalloonTitle:=sDownloadComplete;
   TrayIcon.ShowBalloonHint;
-{$endif CPUARM}
 end;
 
 function TMainForm.GetFlagImage(const CountryCode: string): integer;
@@ -4109,11 +4105,7 @@ begin
 end;
 
 procedure TMainForm.ApplicationPropertiesMinimize(Sender: TObject);
-begin
-{$ifdef CPUARM}
-  exit;
-{$endif  CPUARM}
-
+begins
 {$ifndef darwin}
   if not IsUnity and Ini.ReadBool('Interface', 'TrayMinimize', True) then
     HideApp;
@@ -4739,12 +4731,6 @@ end;
 
 procedure TMainForm.FormClose(Sender: TObject; var CloseAction: TCloseAction);
 begin
-{$ifdef CPUARM}
-//  CloseAction:=caMinimize;
-  BeforeCloseApp;
-  exit;
-{$endif CPUARM}
-
   if Ini.ReadBool('Interface', 'TrayClose', False) then begin
 {$ifdef darwin}
     CloseAction:=caMinimize;

--- a/main.pas
+++ b/main.pas
@@ -4105,7 +4105,7 @@ begin
 end;
 
 procedure TMainForm.ApplicationPropertiesMinimize(Sender: TObject);
-begins
+begin
 {$ifndef darwin}
   if not IsUnity and Ini.ReadBool('Interface', 'TrayMinimize', True) then
     HideApp;


### PR DESCRIPTION
`CPUARM` is defined when compiling for 32-bit ARM CPUs. It's hard for me to say what this was used for back in the past (WinCE maybe?) but there's no case where this is defined with the current build pipelines.

Also, bump Lazarus on MacOS due to cherry-picking some commits that fix a crash when starting the IDE.